### PR TITLE
Inari final changes

### DIFF
--- a/src/main/java/theGartic/cards/InariModal/InariEndurance.java
+++ b/src/main/java/theGartic/cards/InariModal/InariEndurance.java
@@ -33,10 +33,10 @@ public class InariEndurance extends EasyModalChoiceCard {
     public InariEndurance(int magicNumber){
         super(NAME, DESCRIPTION, () -> {
             AbstractPlayer p = AbstractDungeon.player;
-            atb(new AddTemporaryHPAction(p, p, magicNumber*12));
+            atb(new AddTemporaryHPAction(p, p, magicNumber*10));
         });
 
-        baseMagicNumber = magicNumber*12;
+        baseMagicNumber = magicNumber*10;
 
         initializeDescription();
     }

--- a/src/main/java/theGartic/cards/InariModal/InariProtection.java
+++ b/src/main/java/theGartic/cards/InariModal/InariProtection.java
@@ -30,10 +30,10 @@ public class InariProtection extends EasyModalChoiceCard {
 
     public InariProtection(int magicNumber) {
         super(NAME, DESCRIPTION, () -> {
-            atb(new GainBlockAction(AbstractDungeon.player, AbstractDungeon.player, magicNumber * 12));
+            atb(new GainBlockAction(AbstractDungeon.player, AbstractDungeon.player, magicNumber * 10));
         });
 
-        baseMagicNumber = magicNumber * 12;
+        baseMagicNumber = magicNumber * 10;
         initializeDescription();
     }
 }

--- a/src/main/java/theGartic/cards/SupplicateToInari.java
+++ b/src/main/java/theGartic/cards/SupplicateToInari.java
@@ -23,7 +23,7 @@ public class SupplicateToInari extends AbstractEasyCard  {
     public static final String DESCRIPTION = cardStrings.DESCRIPTION;
     private static final CardRarity RARITY = CardRarity.RARE;
     private static final CardTarget TARGET = CardTarget.SELF;
-    private static final CardType TYPE = CardType.SKILL;
+    private static final CardType TYPE = CardType.POWER;
     public static final CardColor COLOR = TheGartic.Enums.GARTIC_COLOR;
 
     private final static int MAGIC = 0;

--- a/src/main/resources/garticmodResources/localization/eng/Cardstrings.json
+++ b/src/main/resources/garticmodResources/localization/eng/Cardstrings.json
@@ -294,7 +294,7 @@
     "DESCRIPTION": "The target loses !D! HP. If it has Block, it loses !D! HP again."
   },
   "${ModID}:SupplicateToInari": {
-    "NAME": "Suplicate To Inari",
+    "NAME": "Supplicate To Inari",
     "DESCRIPTION": "Summon a Three-Tailed White Fox.",
     "UPGRADE_DESCRIPTION": "Summon a Three-Tailed White Fox.",
     "EXTENDED_DESCRIPTION": [


### PR DESCRIPTION
This fixes #62  and nerfs Inari a bit, both as intended originally and not: as a Power, the player can't accumulate Inari summons, which means they won't be as degenerate as they were before (basically being THE solution if you can block enough to summon more of those).