### PR TITLE
Fixing maven package error

### DIFF
--- a/src/main/java/theGartic/GarticMod.java
+++ b/src/main/java/theGartic/GarticMod.java
@@ -155,7 +155,7 @@ public class GarticMod implements
 
     public void receiveEditPotions() {
         BaseMod.addPotion(PurpleStuff.class, Color.PURPLE.cpy(), Color.PURPLE.cpy(), Color.PURPLE.cpy(), PurpleStuff.ID, TheGartic.Enums.THE_GARTIC);
-        BaseMod.addPotion(CopyingPotion.class, Color.NAVY.cpy(), Color.NAVY.cpy(), Color.NAVY.cpy(), CopyingPotion.ID, TheGartic.Enums.THE_GARTIC);
+        BaseMod.addPotion(CopyingPotion.class, Color.NAVY.cpy(), Color.NAVY.cpy(), Color.NAVY.cpy(), CopyingPotion.POTION_ID, TheGartic.Enums.THE_GARTIC);
         BaseMod.addPotion(DarklingMilk.class, Color.WHITE.cpy(), Color.WHITE.cpy(), Color.WHITE.cpy(), DarklingMilk.ID, TheGartic.Enums.THE_GARTIC);
     }
 


### PR DESCRIPTION
When I tried to maven package the current build, I couldn't thanks to the error below:

TheGartic/src/main/java/theGartic/GarticMod.java:[158,115] non-static variable ID cannot be referenced from a static context 

This PR fixes that.