### PR TITLE
Inari tweaks

### DIFF
--- a/src/main/java/theGartic/cards/summonOptions/AbstractSummonOption.java
+++ b/src/main/java/theGartic/cards/summonOptions/AbstractSummonOption.java
@@ -38,7 +38,7 @@ public abstract class AbstractSummonOption  extends AbstractEasyCard
             weightedSummons.put(MischievousFoxOption.ID, 40);
             weightedSummons.put(PandaOption.ID, 20);
             weightedSummons.put(DireWolfOption.ID, 20);
-            weightedSummons.put(InariOption.ID, 4);
+            weightedSummons.put(InariOption.ID, 1);
         }
     }
 

--- a/src/main/resources/garticmodResources/localization/eng/Cardstrings.json
+++ b/src/main/resources/garticmodResources/localization/eng/Cardstrings.json
@@ -307,8 +307,8 @@
   },
   "${ModID}:SupplicateToInari": {
     "NAME": "Supplicate To Inari",
-    "DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox.",
-    "UPGRADE_DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox.",
+    "DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox, that at the end of your turn, gives 1 of 3 random positive choices.",
+    "UPGRADE_DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox, that at the end of your turn, gives 1 of 3 random positive choices.",
     "EXTENDED_DESCRIPTION": [
       " NL Draw !M! card.",
       " NL Draw !M! cards.",

--- a/src/main/resources/garticmodResources/localization/eng/Powerstrings.json
+++ b/src/main/resources/garticmodResources/localization/eng/Powerstrings.json
@@ -146,7 +146,7 @@
   "${ModID}:InariDashPower": {
     "NAME": "Inari Dash",
     "DESCRIPTIONS": [
-      "if you play a card, draw #b",
+      "If you play a card, draw #b",
       " card.",
       " cards.",
       " This Power is removed at the end of this turn."


### PR DESCRIPTION
Major changes:

* Adjusted the chance of a Three-Tailed White Fox being available to (_if my calculations are right_) 1/241 per roll through Tall Grass and Spiked Collar;
* Fixed a typo on Inari Dash power's description;
* Added a better description to Supplicate To Inari.