### PR TITLE
Sure shot (and Inari) fixes

### DIFF
--- a/src/main/java/theGartic/cards/SureShot.java
+++ b/src/main/java/theGartic/cards/SureShot.java
@@ -26,17 +26,17 @@ public class SureShot extends AbstractEasyCard {
     public static final CardColor COLOR = TheGartic.Enums.GARTIC_COLOR;
 
     public SureShot() {
-        super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
+        super(ID, 1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.ENEMY);
         baseDamage = 8;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m)
     {
         if (m.currentBlock > 0){
-            atb(new DamageAction(m, new DamageInfo(AbstractDungeon.player, baseDamage, DamageInfo.DamageType.HP_LOSS),
+            atb(new DamageAction(m, new DamageInfo(AbstractDungeon.player, damage, DamageInfo.DamageType.HP_LOSS),
                     AbstractGameAction.AttackEffect.SLASH_HORIZONTAL));
         }
-        atb(new DamageAction(m, new DamageInfo(AbstractDungeon.player, baseDamage, DamageInfo.DamageType.HP_LOSS),
+        atb(new DamageAction(m, new DamageInfo(AbstractDungeon.player, damage, DamageInfo.DamageType.HP_LOSS),
                 AbstractGameAction.AttackEffect.SLASH_HORIZONTAL));
     }
 

--- a/src/main/resources/garticmodResources/localization/eng/Cardstrings.json
+++ b/src/main/resources/garticmodResources/localization/eng/Cardstrings.json
@@ -311,8 +311,8 @@
   },
   "${ModID}:SupplicateToInari": {
     "NAME": "Supplicate To Inari",
-    "DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox, that at the end of your turn, gives 1 of 3 random positive choices.",
-    "UPGRADE_DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox, that at the end of your turn, gives 1 of 3 random positive choices.",
+    "DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox.",
+    "UPGRADE_DESCRIPTION": "Summon a ${ModID}:Three-Tailed\u00a0White\u00a0Fox.",
     "EXTENDED_DESCRIPTION": [
       " NL Draw !M! card.",
       " NL Draw !M! cards.",
@@ -525,7 +525,7 @@
   },
   "${ModID}:InariOption": {
     "NAME": "Three-Tailed White Fox",
-    "DESCRIPTION": "When your turn ends, pick 1 of 3 choices."
+    "DESCRIPTION": "When your turn ends, pick 1 of 3 positive choices."
   },
   "${ModID}:MirroredFoxOption": {
     "NAME": "Mirrored Fox",


### PR DESCRIPTION
Major Changes:

* Sure Shot now scales with Str and other powers properly;
* Supplicate To Inari has a shorter description now - it's not needed anymore as its pet tooltip has the necessary info and also it shouldn't be affected by Paper Bunny.